### PR TITLE
Fixing installation for `prompttools` example

### DIFF
--- a/examples/prompttools-eval-prompts/main.ipynb
+++ b/examples/prompttools-eval-prompts/main.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --quiet --force-reinstall prompttools lancedb"
+    "!pip install --quiet --force-reinstall prompttools lancedb sentence_transformers"
    ]
   },
   {


### PR DESCRIPTION
The library `sentence_transformers` is necessary for this notebook example

cc: @AyushExel 