### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/examples/SuperAgent_Autogen/main.ipynb
+++ b/examples/SuperAgent_Autogen/main.ipynb
@@ -61,7 +61,7 @@
         }
       ],
       "source": [
-        "%pip install pyautogen~=0.1.0  langchain langchain_community openai tiktoken lancedb pypdf -q -U"
+        "%pip install ag2~=0.1.0  langchain langchain_community openai tiktoken lancedb pypdf -q -U"
       ]
     },
     {
@@ -90,7 +90,7 @@
         "Requirements\n",
         "AutoGen requires Python>=3.8.\n",
         "\n",
-        "To run this notebook example, please install `pyautogen`:\n"
+        "To run this notebook example, please install `ag2`:\n"
       ]
     },
     {
@@ -108,34 +108,34 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Requirement already satisfied: pyautogen in /usr/local/lib/python3.10/dist-packages (0.1.14)\n",
-            "Requirement already satisfied: diskcache in /usr/local/lib/python3.10/dist-packages (from pyautogen) (5.6.3)\n",
-            "Requirement already satisfied: flaml in /usr/local/lib/python3.10/dist-packages (from pyautogen) (2.3.2)\n",
-            "Requirement already satisfied: openai<1 in /usr/local/lib/python3.10/dist-packages (from pyautogen) (0.28.1)\n",
-            "Requirement already satisfied: python-dotenv in /usr/local/lib/python3.10/dist-packages (from pyautogen) (1.0.1)\n",
-            "Requirement already satisfied: termcolor in /usr/local/lib/python3.10/dist-packages (from pyautogen) (2.5.0)\n",
-            "Requirement already satisfied: requests>=2.20 in /usr/local/lib/python3.10/dist-packages (from openai<1->pyautogen) (2.32.3)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.10/dist-packages (from openai<1->pyautogen) (4.66.6)\n",
-            "Requirement already satisfied: aiohttp in /usr/local/lib/python3.10/dist-packages (from openai<1->pyautogen) (3.11.2)\n",
-            "Requirement already satisfied: NumPy>=1.17 in /usr/local/lib/python3.10/dist-packages (from flaml->pyautogen) (1.26.4)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->pyautogen) (3.4.0)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->pyautogen) (3.10)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->pyautogen) (2.2.3)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->pyautogen) (2024.8.30)\n",
-            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (2.4.3)\n",
-            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (1.3.1)\n",
-            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (24.2.0)\n",
-            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (1.5.0)\n",
-            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (6.1.0)\n",
-            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (0.2.0)\n",
-            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (1.17.2)\n",
-            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->pyautogen) (4.0.3)\n",
-            "Requirement already satisfied: typing-extensions>=4.1.0 in /usr/local/lib/python3.10/dist-packages (from multidict<7.0,>=4.5->aiohttp->openai<1->pyautogen) (4.12.2)\n"
+            "Requirement already satisfied: ag2 in /usr/local/lib/python3.10/dist-packages (0.1.14)\n",
+            "Requirement already satisfied: diskcache in /usr/local/lib/python3.10/dist-packages (from ag2) (5.6.3)\n",
+            "Requirement already satisfied: flaml in /usr/local/lib/python3.10/dist-packages (from ag2) (2.3.2)\n",
+            "Requirement already satisfied: openai<1 in /usr/local/lib/python3.10/dist-packages (from ag2) (0.28.1)\n",
+            "Requirement already satisfied: python-dotenv in /usr/local/lib/python3.10/dist-packages (from ag2) (1.0.1)\n",
+            "Requirement already satisfied: termcolor in /usr/local/lib/python3.10/dist-packages (from ag2) (2.5.0)\n",
+            "Requirement already satisfied: requests>=2.20 in /usr/local/lib/python3.10/dist-packages (from openai<1->ag2) (2.32.3)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.10/dist-packages (from openai<1->ag2) (4.66.6)\n",
+            "Requirement already satisfied: aiohttp in /usr/local/lib/python3.10/dist-packages (from openai<1->ag2) (3.11.2)\n",
+            "Requirement already satisfied: NumPy>=1.17 in /usr/local/lib/python3.10/dist-packages (from flaml->ag2) (1.26.4)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->ag2) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->ag2) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->ag2) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai<1->ag2) (2024.8.30)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (2.4.3)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (1.3.1)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (24.2.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (0.2.0)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (1.17.2)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai<1->ag2) (4.0.3)\n",
+            "Requirement already satisfied: typing-extensions>=4.1.0 in /usr/local/lib/python3.10/dist-packages (from multidict<7.0,>=4.5->aiohttp->openai<1->ag2) (4.12.2)\n"
           ]
         }
       ],
       "source": [
-        "!pip install pyautogen"
+        "!pip install ag2"
       ]
     },
     {
@@ -422,7 +422,7 @@
       "outputs": [],
       "source": [
         "# install autogen\n",
-        "!pip install pyautogen -q"
+        "!pip install ag2 -q"
       ]
     },
     {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
