### PR TITLE
Simplify Geneva demo

### DIFF
--- a/tutorials/feature-engineering/feature-engineering-101.ipynb
+++ b/tutorials/feature-engineering/feature-engineering-101.ipynb
@@ -4,21 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The tutorial is divided into two parts:\n",
+    "The tutorial has three parts:\n",
     "\n",
-    "*   **Part 1: Feature Engineering with LanceDB and Geneva**: In this part, we'll focus on the crucial process of feature engineering. We'll use LanceDB and its Geneva feature engineering framework to enrich our data with meaningful features that will power our search engine.\n",
+    "*   **Part 1: Feature Engineering with LanceDB and Geneva**: First, we'll focus on the crucial process of feature engineering. We'll use LanceDB and its Geneva feature engineering framework to enrich our data with meaningful features that will power our search engine.\n",
     "\n",
-    "*   **Part 2: Inference and Retrieval with LanceDB**: In this part, we'll build the inference and retrieval pipeline that uses the features we engineered in Part 1 to provide a powerful and intuitive search experience. We'll cover query routing, hybrid search, and reranking to build a state-of-the-art search engine. \n",
+    "*   **Part 2: Materialized Views**: We'll create materialized views: precomputed queries stored as physical tables for quick access.\n",
     "\n",
-    "## Part 1: Feature Engineering with LanceDB and Geneva\n",
+    "*   **Part 3: Feature Engineering on Remote Ray Clusters**: We'll focus on how to make your feature engineering pipeline production-ready, using Geneva Clusters and Manifests to easily work with Ray clusters.\n",
+    "\n",
+    "## Part 1: Feature Engineering with LanceDB and Gene}va\n",
     "\n",
     "This notebook is the first part of our tutorial on building an advanced product search engine. In this part, we will focus on the crucial process of feature engineering. We'll start with a raw dataset of fashion products, and ingest it in LanceDB. We'll then use Geneva to enrich our data with meaningful features that will power our search engine.\n",
     "\n",
     "We will cover the following steps:\n",
     "1. **Data Ingestion**: Downloading a fashion dataset and loading it into a LanceDB table.\n",
     "2. **Declarative Feature Engineering**: Using Geneva to define and compute features on-the-fly.\n",
-    "3. **Embedding Generation**: Creating vector embeddings for both images and text to enable semantic search.\n",
-    "4. **Indexing**: Creating indexes to speed up our queries."
+    "3. **Embedding Generation**: Creating vector embeddings for both images and text to enable semantic search."
    ]
   },
   {
@@ -49,19 +50,13 @@
    },
    "outputs": [],
    "source": [
-    "!sudo rm -r db fashion-dataset # Delete if already exists\n",
+    "#!sudo rm -r db fashion-dataset # Uncomment and run this to delete the dataset if it already exists\n",
     "\n",
-    "# ### HIGH RES DATASET (Slow to download) #\n",
-    "#!curl -L -o fashion-product-images-dataset.zip\\\n",
-    "#  https://www.kaggle.com/api/v1/datasets/download/paramaggarwal/fashion-product-images-dataset\n",
-    "\n",
-    "#!unzip -q fashion-product-images-dataset.zip \n",
-    "\n",
-    "# SAME DATASET WITH LOW RES IMAGES #\n",
-    "\n",
-    "!curl -L -o fashion-product-images-small.zip\\\n",
-    "  https://www.kaggle.com/api/v1/datasets/download/paramaggarwal/fashion-product-images-small\n",
-    "!unzip -q fashion-product-images-small.zip -d fashion-dataset/"
+    "# Download the dataset if it doesn't exist\n",
+    "!test -d fashion-dataset && test -n \"$(ls -A fashion-dataset 2>/dev/null)\" && \\\n",
+    "  echo \"Dataset already exists, skipping download\" || \\\n",
+    "    (curl -L -o fashion-product-images-small.zip https://www.kaggle.com/api/v1/datasets/download/paramaggarwal/fashion-product-images-small \\\n",
+    "    && unzip -q fashion-product-images-small.zip -d fashion-dataset/)"
    ]
   },
   {
@@ -194,18 +189,9 @@
     "1. Prototype your Python function in your favorite environment.\n",
     "2. Wrap the function with small UDF decorator.\n",
     "3. Register the UDF as a virtual column using Table.add_columns().\n",
-    "4. Trigger a backfill operation.\n",
-    "There are various kinds of UDFs you can use depending on the task type\n",
+    "4. Trigger a backfill operation\n",
     "\n",
-    "* **Row-level, stateless UDFs** - You can use these when you're tasks don't need to be optimized with batch processing, and they don't require complex setup each time\n",
-    "* **Row-level, stateful UDFs** - You can use these when you're tasks don't need to be optimized with batch processing, and they require complex setup each time\n",
-    "* **Batched, Statless UDFs** - You can use these when batch processing is faster but you don't require complex setup each time.\n",
-    "* **Batched, Stateful UDFs** - You can use these when batch processing is faster AND you require complex setup (like loading model) for each batch.\n",
-    "Read more about geneva UDFs here - TODO: Add new docs link\n",
-    "\n",
-    "In this example we'll use Batched, Stateful UDF\n",
-    "\n",
-    "NOTE: num_gpus>0 means this UDF is meant to run on GPU nodes\n",
+    "UDFs can work on one row or a batch at a time, and can be stateful (e.g. some work is done to set up a model the first time, and future runs use the same model) or stateless. [Read more about geneva UDFs here.](https://docs.lancedb.com/geneva/udfs)\n",
     "\n",
     "### Simple Feature Extraction\n",
     "\n",
@@ -290,10 +276,10 @@
     "\n",
     "Checkpoints: Each batch of UDF execution is checkpointed so that partial results are not lost in case of job failures. Jobs can resume and avoid most of the expense of having to recalculate values.\n",
     "\n",
-    "backfill accepts various params to customise scale of your workload, here we'll use:\n",
+    "`backfill()` accepts various params to customise scale of your workload, here we'll use:\n",
     "\n",
-    "* **checkpoint_size**  - Which determines the number of rows that are processed before writing a checkpoint\n",
-    "* **concurrency** - Which determins how many nodes are used for parallelization\n",
+    "* `checkpoint_size` - the number of rows that are processed before writing a checkpoint\n",
+    "* `concurrency` - how many nodes are used for parallelization\n",
     "\n",
     "Here, we're using geneva locally, so we won't set up a Ray cluster, but you can also use the same setup and run distributed jobs remotely on Ray clusters."
    ]
@@ -507,12 +493,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Indexing\n",
+    "## 4. Wrapping up\n",
     "\n",
-    "To speed up our queries, we need to create indexes on our new features. We'll create two types of indexes:\n",
-    "\n",
-    "*   **Full-Text Search (FTS) Index**: This will allow us to quickly search for keywords in our `description` column.\n",
-    "*   **Vector Index**: This will allow us to perform fast similarity searches on our `image_embedding` column."
+    "That's the basics of feature engineering! If you wanted to go on to query this table, you might build indexes, as in the next cell:"
    ]
   },
   {
@@ -523,36 +506,10 @@
    },
    "outputs": [],
    "source": [
-    "table.create_fts_index(\"caption\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "# Full-Text Search (FTS) Index: This will allow us to quickly search for keywords in our `caption` column.\n",
+    "table.create_fts_index(\"caption\")\n",
+    "# Vector Index: This will allow us to perform fast similarity searches on our `image_embedding` column.\n",
     "table.create_index(vector_column_name=\"image_embedding\", num_sub_vectors=128)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "table.list_indices()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "That's it for the feature engineering part! We now have a LanceDB table enriched with a variety of features that will power our search engine. In the next part of this tutorial, we'll build the inference and retrieval pipeline that uses these features to provide a powerful and intuitive search experience."
    ]
   }
  ],


### PR DESCRIPTION
Part 1 of the Geneva clothes demo. Still have to add bits to build materialized views, connect to Ray clusters, and try out other advanced features, but this should get users up and running Geneva instantly.

Changes from the previous version:
- remove the Gemini features. they're cool but the free tier is so limited (20 requests/day) so it basically requires a paid Gemini account. Even if the free tier let you run it all, I want to put fewer steps between users and seeing value.
- add simple clip embeddings and blip captions. So now the workflow is:
1. set up, load data
2. create a simple derived feature
3. clip embeddings
4. blip captions
5. create indexes
- make "restart and run all" work
- make it work on colab
- clear outputs