### PR TITLE
Feature eng 101 bugfixes

### DIFF
--- a/tutorials/feature-engineering/feature-engineering-101.ipynb
+++ b/tutorials/feature-engineering/feature-engineering-101.ipynb
@@ -77,7 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "# Especially if on Colab, start with just 100 rows for speed.\n",
+    "# Especially if on Colab, start with just 100 rows for testing.\n",
     "DATASET_SIZE = 100\n",
     "# Increase this if you're running locally, you have more CPUs available and want it to run faster.\n",
     "CONCURRENCY = 4\n",


### PR DESCRIPTION
- fix where we tried to index a table using a float; thanks again to @michael-lancedb for noticing this!
- remove "build indexes" at the end, because if you're running this off the shelf, you'll only have 150 rows in your table; this is good for speed but you can't build a vector index with 150 vectors. Plus, building indexes isn't really a Geneva concern anyway.