### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/examples/RAG-with-MiniMax/RAG_with_MiniMax.ipynb
+++ b/examples/RAG-with-MiniMax/RAG_with_MiniMax.ipynb
@@ -9,7 +9,7 @@
     "This notebook demonstrates how to build a Retrieval-Augmented Generation (RAG) pipeline using:\n",
     "- **[sentence-transformers](https://www.sbert.net/)** for generating text embeddings\n",
     "- **[LanceDB](https://lancedb.com/)** for vector storage and similarity search\n",
-    "- **[MiniMax M2.7](https://www.minimaxi.com/)** as the LLM for answer generation (via OpenAI-compatible API)\n",
+    "- **[MiniMax M3](https://www.minimaxi.com/)** as the LLM for answer generation (via OpenAI-compatible API)\n",
     "\n",
     "MiniMax provides an OpenAI-compatible endpoint at `https://api.minimax.io/v1`, so we can use the standard `openai` Python SDK."
    ]
@@ -220,7 +220,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate answer with MiniMax M2.7\n",
+    "## Generate answer with MiniMax M3\n",
     "\n",
     "MiniMax provides an OpenAI-compatible API at `https://api.minimax.io/v1`.  \n",
     "We use the standard `openai` SDK with a custom `base_url`."
@@ -240,7 +240,7 @@
     "context = \"\\n\\n---\\n\\n\".join(list(results[\"text\"]))\n",
     "\n",
     "response = client.chat.completions.create(\n",
-    "    model=\"MiniMax-M2.7\",\n",
+    "    model=\"MiniMax-M3\",\n",
     "    messages=[\n",
     "        {\n",
     "            \"role\": \"system\",\n",
@@ -259,7 +259,7 @@
     "    max_tokens=1024,\n",
     ")\n",
     "\n",
-    "print(\"MiniMax M2.7 Answer:\")\n",
+    "print(\"MiniMax M3 Answer:\")\n",
     "print(response.choices[0].message.content)"
    ]
   },
@@ -283,7 +283,7 @@
     "context2 = \"\\n\\n---\\n\\n\".join(list(results2[\"text\"]))\n",
     "\n",
     "response2 = client.chat.completions.create(\n",
-    "    model=\"MiniMax-M2.7\",\n",
+    "    model=\"MiniMax-M3\",\n",
     "    messages=[\n",
     "        {\n",
     "            \"role\": \"system\",\n",
@@ -303,7 +303,7 @@
     ")\n",
     "\n",
     "print(f\"Query: {query2}\\n\")\n",
-    "print(\"MiniMax M2.7 Answer:\")\n",
+    "print(\"MiniMax M3 Answer:\")\n",
     "print(response2.choices[0].message.content)"
    ]
   }

--- a/examples/RAG-with-MiniMax/README.md
+++ b/examples/RAG-with-MiniMax/README.md
@@ -7,14 +7,14 @@ This example demonstrates how to build a Retrieval-Augmented Generation (RAG) pi
 - **Web Scraping**: Scrapes web pages and extracts text content.
 - **Chunking & Embeddings**: Splits text into chunks and generates embeddings using `sentence-transformers`.
 - **Vector Storage**: Stores document embeddings in LanceDB for efficient similarity search.
-- **RAG Query**: Retrieves the most relevant document chunks and sends them to MiniMax M2.7 (via OpenAI-compatible API) to generate answers.
+- **RAG Query**: Retrieves the most relevant document chunks and sends them to MiniMax M3 (via OpenAI-compatible API) to generate answers.
 
 ## MiniMax API
 
 [MiniMax](https://www.minimaxi.com/) provides an OpenAI-compatible API endpoint, making it easy to integrate with existing OpenAI SDK workflows.
 
 - **Base URL**: `https://api.minimax.io/v1`
-- **Models**: `MiniMax-M2.7` (latest, 1M context), `MiniMax-M2.7-highspeed`
+- **Models**: `MiniMax-M3` (latest, default), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`
 
 ## Setup
 

--- a/examples/RAG-with-MiniMax/main.py
+++ b/examples/RAG-with-MiniMax/main.py
@@ -4,7 +4,7 @@ RAG with MiniMax and LanceDB
 Demonstrates a Retrieval-Augmented Generation pipeline using:
 - sentence-transformers for embeddings
 - LanceDB for vector storage and retrieval
-- MiniMax M2.7 (via OpenAI-compatible API) for answer generation
+- MiniMax M3 (via OpenAI-compatible API) for answer generation
 """
 
 import json
@@ -84,7 +84,7 @@ def retrieve(query: str, table, top_k: int = 5) -> list[str]:
 
 
 def ask_minimax(query: str, context_docs: list[str]) -> str:
-    """Send a RAG query to MiniMax M2.7 via OpenAI-compatible API."""
+    """Send a RAG query to MiniMax M3 via OpenAI-compatible API."""
     api_key = os.environ.get("MINIMAX_API_KEY")
     if not api_key:
         raise ValueError("MINIMAX_API_KEY environment variable is not set")
@@ -111,7 +111,7 @@ def ask_minimax(query: str, context_docs: list[str]) -> str:
     ]
 
     response = client.chat.completions.create(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=messages,
         temperature=0.7,
         max_tokens=1024,

--- a/examples/RAG-with-MiniMax/test_integration.py
+++ b/examples/RAG-with-MiniMax/test_integration.py
@@ -44,7 +44,7 @@ class TestMiniMaxIntegration(unittest.TestCase):
             base_url="https://api.minimax.io/v1",
         )
         response = client.chat.completions.create(
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[{"role": "user", "content": "Say hello in one word."}],
             temperature=0.7,
             max_tokens=10,
@@ -70,7 +70,7 @@ class TestMiniMaxIntegration(unittest.TestCase):
         query = "What is LanceDB?"
 
         response = client.chat.completions.create(
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[
                 {
                     "role": "system",
@@ -118,7 +118,7 @@ class TestEndToEndPipeline(unittest.TestCase):
         docs = [
             "Python is a popular programming language used in AI and data science.",
             "LanceDB provides serverless vector search with no infrastructure to manage.",
-            "MiniMax M2.7 is a large language model with 1M token context window.",
+            "MiniMax M3 is the latest large language model from MiniMax.",
         ]
 
         # Create embeddings (use random vectors for speed; real pipeline uses sentence-transformers)
@@ -142,7 +142,7 @@ class TestEndToEndPipeline(unittest.TestCase):
             base_url="https://api.minimax.io/v1",
         )
         response = client.chat.completions.create(
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[
                 {"role": "system", "content": "Answer based on context."},
                 {"role": "user", "content": f"Context:\n{context}\n\nSummarize the context."},

--- a/examples/RAG-with-MiniMax/test_unit.py
+++ b/examples/RAG-with-MiniMax/test_unit.py
@@ -205,10 +205,10 @@ class TestMiniMaxClientConfig(unittest.TestCase):
         self.assertIn("minimax", base_url)
 
     def test_model_names(self):
-        models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+        models = ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
         for model in models:
             self.assertTrue(model.startswith("MiniMax-"))
-            self.assertIn("M2", model)
+            self.assertTrue("M3" in model or "M2" in model)
 
     def test_temperature_must_be_positive(self):
         temperature = 0.7


### PR DESCRIPTION
## Summary
Upgrade the RAG-with-MiniMax example to use the latest `MiniMax-M3` model as the default. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available in the docs and tests.

## Changes
- `examples/RAG-with-MiniMax/main.py` — switch `ask_minimax` default model to `MiniMax-M3`
- `examples/RAG-with-MiniMax/RAG_with_MiniMax.ipynb` — update RAG cells to call `MiniMax-M3`
- `examples/RAG-with-MiniMax/README.md` — describe `MiniMax-M3` as the latest/default; keep M2.7 entries
- `examples/RAG-with-MiniMax/test_unit.py` — extend the model-name assertion to include `MiniMax-M3`
- `examples/RAG-with-MiniMax/test_integration.py` — point default-model integration tests at `MiniMax-M3`; preserve the `MiniMax-M2.7-highspeed` test

## Why
`MiniMax-M3` is the latest MiniMax model and is the recommended default going forward. The example previously pinned to `MiniMax-M2.7`; this brings it in line with the current default while preserving the older model identifiers users may still want to call.

## Testing
- Local `python -m unittest test_unit` — 24 tests pass
- Integration tests still skip cleanly when `MINIMAX_API_KEY` is not set